### PR TITLE
Added "path2regex" regex caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@
 
 var path2regex = require('path-to-regexp');
 
+var cache = Object.create(null);
 
 module.exports = function reverend(route, obj) {
     var keys, path, routeRegex;
@@ -34,9 +35,19 @@ module.exports = function reverend(route, obj) {
         throw new TypeError('route must be a String path');
     }
 
-    keys = [];
+    if (route in cache) {
+        keys = cache[route].keys;
+        routeRegex = cache[route].routeRegex;
+    } else {
+        keys = [];
+        routeRegex = path2regex(route, keys);
+        cache[route] = {
+            keys: keys,
+            routeRegex: routeRegex
+        };
+    }
+
     path = route;
-    routeRegex = path2regex(route, keys);
 
     keys.forEach(function (key) {
         var value, regex;


### PR DESCRIPTION
`path2regex` generates new regexs everytime `reverend` is called. Since `path2regex` is deterministic, we can avoid taxing the GC by caching its results.

I considered also including a `nocache` option, and/or exposing a `clearCache()` method, but it doesn't seem very useful. Let me know if that's something I should include in this PR.